### PR TITLE
Track line numbers in lexer and update formatting accordingly

### DIFF
--- a/huff_lexer/src/lib.rs
+++ b/huff_lexer/src/lib.rs
@@ -668,6 +668,10 @@ impl<'a> Lexer<'a> {
         }
         imports
     }
+
+    pub fn line_number(&self) -> usize {
+        self.line_number
+    }
 }
 
 impl<'a> Iterator for Lexer<'a> {

--- a/huff_lexer/tests/arg_calls.rs
+++ b/huff_lexer/tests/arg_calls.rs
@@ -63,21 +63,41 @@ fn lexes_arg_calls() {
 
     // We should find a left angle
     let tok = lexer.next().unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::LeftAngle, Span::new(184..184, None)));
+    assert_eq!(
+        tok,
+        Token::new(TokenKind::LeftAngle, Span::new(184..184, None), lexer.line_number())
+    );
 
     // The we should have an Ident
     let tok = lexer.next().unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::Ident("error".to_string()), Span::new(185..189, None)));
+    assert_eq!(
+        tok,
+        Token::new(
+            TokenKind::Ident("error".to_string()),
+            Span::new(185..189, None),
+            lexer.line_number()
+        )
+    );
 
     // Then should find a right angle
     let tok = lexer.next().unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::RightAngle, Span::new(190..190, None)));
+    assert_eq!(
+        tok,
+        Token::new(TokenKind::RightAngle, Span::new(190..190, None), lexer.line_number())
+    );
 
     let _ = lexer.next(); // Whitespace
 
     // Jumpi Opcode
     let tok = lexer.next().unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::Opcode(Opcode::Jumpi), Span::new(192..196, None)));
+    assert_eq!(
+        tok,
+        Token::new(
+            TokenKind::Opcode(Opcode::Jumpi),
+            Span::new(192..196, None),
+            lexer.line_number()
+        )
+    );
 
     // Eat the rest of the tokens
     let _ = lexer.next(); // Whitespace
@@ -88,7 +108,11 @@ fn lexes_arg_calls() {
     let tok = lexer.next().unwrap().unwrap();
     assert_eq!(
         tok,
-        Token::new(TokenKind::Eof, Span::new(source.len() - 1..source.len() - 1, None))
+        Token::new(
+            TokenKind::Eof,
+            Span::new(source.len() - 1..source.len() - 1, None),
+            lexer.line_number()
+        )
     );
 
     // We should have reached EOF now

--- a/huff_lexer/tests/builtins.rs
+++ b/huff_lexer/tests/builtins.rs
@@ -56,7 +56,11 @@ fn parses_builtin_function_in_macro_body() {
         let builtin_span = Span::new(74..74 + builtin.len() - 1, None);
         assert_eq!(
             unwrapped,
-            Token::new(TokenKind::BuiltinFunction(builtin.to_string()), builtin_span.clone())
+            Token::new(
+                TokenKind::BuiltinFunction(builtin.to_string()),
+                builtin_span.clone(),
+                lexer.line_number()
+            )
         );
 
         let _ = lexer.next(); // open parenthesis
@@ -96,7 +100,11 @@ fn fails_to_parse_builtin_outside_macro_body() {
         let fn_name_span = Span::new(0..builtin.len() - 1, None);
         assert_eq!(
             unwrapped,
-            Token::new(TokenKind::BuiltinFunction(builtin.to_string()), fn_name_span.clone())
+            Token::new(
+                TokenKind::BuiltinFunction(builtin.to_string()),
+                fn_name_span.clone(),
+                lexer.line_number()
+            )
         );
 
         let _ = lexer.next(); // open parenthesis
@@ -155,7 +163,11 @@ fn fails_to_parse_invalid_builtin() {
         let builtin_span = Span::new(74..74 + builtin.len() - 1, None);
         assert_eq!(
             unwrapped,
-            Token::new(TokenKind::BuiltinFunction(builtin.to_string()), builtin_span.clone())
+            Token::new(
+                TokenKind::BuiltinFunction(builtin.to_string()),
+                builtin_span.clone(),
+                lexer.line_number()
+            )
         );
 
         let _ = lexer.next(); // open parenthesis

--- a/huff_lexer/tests/comments.rs
+++ b/huff_lexer/tests/comments.rs
@@ -29,61 +29,68 @@ fn single_line_comments() {
     let unwrapped = tok.unwrap().unwrap();
     assert_eq!(
         unwrapped,
-        Token::new(TokenKind::Comment("// comment contents ".to_string()), Span::new(0..19, None))
+        Token::new(
+            TokenKind::Comment("// comment contents ".to_string()),
+            Span::new(0..19, None),
+            lexer.line_number()
+        )
     );
 
     // The second token should be the newline character parsed as a whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(20..20, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span, lexer.line_number()));
 
     // This token should be a Define identifier
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(21..27, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span, lexer.line_number()));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(28..28, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span, lexer.line_number()));
 
     // Then we should parse the macro keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let macro_span = Span::new(29..33, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Macro, macro_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Macro, macro_span, lexer.line_number()));
 
     // The next token should be another whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let ws_span = Span::new(34..34, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, ws_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, ws_span, lexer.line_number()));
 
     // Then we should get the function name
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let function_span = Span::new(35..45, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Ident("HELLO_WORLD".to_string()), function_span));
+    assert_eq!(
+        unwrapped,
+        Token::new(TokenKind::Ident("HELLO_WORLD".to_string()), function_span, lexer.line_number())
+    );
 
     // Then we should have an open paren
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let open_paren_span = Span::new(46..46, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::OpenParen, open_paren_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::OpenParen, open_paren_span, lexer.line_number()));
 
     // Lastly, we should have a closing parenthesis
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let close_paren_span = Span::new(47..47, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::CloseParen, close_paren_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::CloseParen, close_paren_span, lexer.line_number()));
 
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let eof_span = Span::new(47..47, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Eof, eof_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Eof, eof_span, lexer.line_number()));
 
     // We covered the whole source
     assert!(lexer.eof);
@@ -101,55 +108,62 @@ fn multi_line_comments() {
     let unwrapped = tok.unwrap().unwrap();
     assert_eq!(
         unwrapped,
-        Token::new(TokenKind::Comment("/* comment contents*/".to_string()), Span::new(0..20, None))
+        Token::new(
+            TokenKind::Comment("/* comment contents*/".to_string()),
+            Span::new(0..20, None),
+            lexer.line_number()
+        )
     );
 
     // This token should be a Define identifier
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(21..27, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span, lexer.line_number()));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(28..28, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span, lexer.line_number()));
 
     // Then we should parse the macro keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let macro_span = Span::new(29..33, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Macro, macro_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Macro, macro_span, lexer.line_number()));
 
     // The next token should be another whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let ws_span = Span::new(34..34, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, ws_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, ws_span, lexer.line_number()));
 
     // Then we should get the function name
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let function_span = Span::new(35..45, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Ident("HELLO_WORLD".to_string()), function_span));
+    assert_eq!(
+        unwrapped,
+        Token::new(TokenKind::Ident("HELLO_WORLD".to_string()), function_span, lexer.line_number())
+    );
 
     // Then we should have an open paren
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let open_paren_span = Span::new(46..46, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::OpenParen, open_paren_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::OpenParen, open_paren_span, lexer.line_number()));
 
     // Lastly, we should have a closing parenthesis
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let close_paren_span = Span::new(47..47, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::CloseParen, close_paren_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::CloseParen, close_paren_span, lexer.line_number()));
 
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let eof_span = Span::new(47..47, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Eof, eof_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Eof, eof_span, lexer.line_number()));
 
     // We covered the whole source
     assert!(lexer.eof);

--- a/huff_lexer/tests/decorators.rs
+++ b/huff_lexer/tests/decorators.rs
@@ -25,13 +25,19 @@ fn parses_decorator() {
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let returns_span = Span::new(13..13, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::Pound, returns_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::Pound, returns_span.clone(), lexer.line_number())
+        );
 
         // [
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let returns_span = Span::new(14..14, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::OpenBracket, returns_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::OpenBracket, returns_span.clone(), lexer.line_number())
+        );
 
         // calldata
         let tok = lexer.next();
@@ -39,14 +45,21 @@ fn parses_decorator() {
         let returns_span = Span::new(15..22, None);
         assert_eq!(
             unwrapped,
-            Token::new(TokenKind::Ident(String::from("calldata")), returns_span.clone())
+            Token::new(
+                TokenKind::Ident(String::from("calldata")),
+                returns_span.clone(),
+                lexer.line_number()
+            )
         );
 
         // (
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let returns_span = Span::new(23..23, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::OpenParen, returns_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::OpenParen, returns_span.clone(), lexer.line_number())
+        );
 
         // 0x01
         let tok = lexer.next();
@@ -54,20 +67,30 @@ fn parses_decorator() {
         let returns_span = Span::new(26..27, None);
         assert_eq!(
             unwrapped,
-            Token::new(TokenKind::Literal(str_to_bytes32("01")), returns_span.clone())
+            Token::new(
+                TokenKind::Literal(str_to_bytes32("01")),
+                returns_span.clone(),
+                lexer.line_number()
+            )
         );
 
         // )
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let returns_span = Span::new(28..28, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::CloseParen, returns_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::CloseParen, returns_span.clone(), lexer.line_number())
+        );
 
         // ]
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let returns_span = Span::new(29..29, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::CloseBracket, returns_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::CloseBracket, returns_span.clone(), lexer.line_number())
+        );
 
         let _ = lexer.next(); // whitespace'
         let _ = lexer.next(); // define

--- a/huff_lexer/tests/eof.rs
+++ b/huff_lexer/tests/eof.rs
@@ -13,7 +13,7 @@ fn end_of_file() {
     // Get an EOF token
     let tok = lexer.next();
     let tok = tok.unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::Eof, Span::new(0..0, None)));
+    assert_eq!(tok, Token::new(TokenKind::Eof, Span::new(0..0, None), lexer.line_number()));
 
     // We should have reached EOF now
     assert!(lexer.eof);

--- a/huff_lexer/tests/fsp.rs
+++ b/huff_lexer/tests/fsp.rs
@@ -9,13 +9,16 @@ fn free_storage_pointer() {
 
     // The first token should be the fsp
     let tok = lexer.next().unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::FreeStoragePointer, Span::new(0..21, None)));
+    assert_eq!(
+        tok,
+        Token::new(TokenKind::FreeStoragePointer, Span::new(0..21, None), lexer.line_number())
+    );
 
     // Eats the whitespace
     let _ = lexer.next();
 
     let tok = lexer.next().unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::Eof, Span::new(22..22, None)));
+    assert_eq!(tok, Token::new(TokenKind::Eof, Span::new(22..22, None), lexer.line_number()));
 
     // We should have reached EOF now
     assert!(lexer.eof);

--- a/huff_lexer/tests/function_type.rs
+++ b/huff_lexer/tests/function_type.rs
@@ -27,7 +27,7 @@ fn parses_function_type() {
         // Lex view first
         let tok = lexer.next().unwrap().unwrap();
         let type_span = Span::new(24..24 + fn_type.len() - 1, None);
-        assert_eq!(tok, Token::new(fn_type_kind, type_span.clone()));
+        assert_eq!(tok, Token::new(fn_type_kind, type_span.clone(), lexer.line_number()));
 
         let _ = lexer.next(); // whitespace
         let _ = lexer.next(); // returns

--- a/huff_lexer/tests/hex.rs
+++ b/huff_lexer/tests/hex.rs
@@ -9,7 +9,14 @@ fn parses_single_hex() {
 
     // The first and only token should be lexed as Literal(0xa57B)
     let tok = lexer.next().unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::Literal(str_to_bytes32("a57B")), Span::new(2..5, None)));
+    assert_eq!(
+        tok,
+        Token::new(
+            TokenKind::Literal(str_to_bytes32("a57B")),
+            Span::new(2..5, None),
+            lexer.line_number()
+        )
+    );
 
     // We covered the whole source
     lexer.next();
@@ -24,13 +31,27 @@ fn parses_bool() {
 
     // The first token should be lexed as a Literal representing 0x00
     let tok = lexer.next().unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::Literal(str_to_bytes32("0")), Span::new(0..4, None)));
+    assert_eq!(
+        tok,
+        Token::new(
+            TokenKind::Literal(str_to_bytes32("0")),
+            Span::new(0..4, None),
+            lexer.line_number()
+        )
+    );
 
     let _ = lexer.next(); // Whitespace
 
     // The second token should be lexed as a Literal representing 0x01
     let tok = lexer.next().unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::Literal(str_to_bytes32("1")), Span::new(6..9, None)));
+    assert_eq!(
+        tok,
+        Token::new(
+            TokenKind::Literal(str_to_bytes32("1")),
+            Span::new(6..9, None),
+            lexer.line_number()
+        )
+    );
 
     // We covered the whole source
     lexer.next();
@@ -45,7 +66,14 @@ fn parses_odd_len_hex() {
 
     // The first and only token should be lexed as Literal(0x1)
     let tok = lexer.next().unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::Literal(str_to_bytes32("1")), Span::new(2..2, None)));
+    assert_eq!(
+        tok,
+        Token::new(
+            TokenKind::Literal(str_to_bytes32("1")),
+            Span::new(2..2, None),
+            lexer.line_number()
+        )
+    );
 
     // We covered the whole source
     lexer.next();

--- a/huff_lexer/tests/imports.rs
+++ b/huff_lexer/tests/imports.rs
@@ -99,7 +99,10 @@ fn include_no_quotes() {
     // The first token should be a single line comment
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
-    assert_eq!(unwrapped, Token::new(TokenKind::Include, Span::new(0..7, None)));
+    assert_eq!(
+        unwrapped,
+        Token::new(TokenKind::Include, Span::new(0..7, None), lexer.line_number())
+    );
     lexer.next();
     assert!(lexer.eof);
 }
@@ -113,13 +116,16 @@ fn include_with_string() {
     // The first token should be a single line comment
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
-    assert_eq!(unwrapped, Token::new(TokenKind::Include, Span::new(0..7, None)));
+    assert_eq!(
+        unwrapped,
+        Token::new(TokenKind::Include, Span::new(0..7, None), lexer.line_number())
+    );
 
     // Lex the whitespace char
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let literal_span = Span::new(8..8, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, literal_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, literal_span, lexer.line_number()));
 
     // Then we should parse the string literal
     let tok = lexer.next();
@@ -129,7 +135,8 @@ fn include_with_string() {
         unwrapped,
         Token::new(
             TokenKind::Str("../huff-examples/erc20/contracts/utils/Ownable.huff".to_string()),
-            literal_span
+            literal_span,
+            lexer.line_number()
         )
     );
 
@@ -148,13 +155,16 @@ fn include_with_string_single_quote() {
     // The first token should be a single line comment
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
-    assert_eq!(unwrapped, Token::new(TokenKind::Include, Span::new(0..7, None)));
+    assert_eq!(
+        unwrapped,
+        Token::new(TokenKind::Include, Span::new(0..7, None), lexer.line_number())
+    );
 
     // Lex the whitespace char
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let literal_span = Span::new(8..8, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, literal_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, literal_span, lexer.line_number()));
 
     // Then we should parse the string literal
     let tok = lexer.next();
@@ -164,7 +174,8 @@ fn include_with_string_single_quote() {
         unwrapped,
         Token::new(
             TokenKind::Str("../huff-examples/erc20/contracts/utils/Ownable.huff".to_string()),
-            literal_span
+            literal_span,
+            lexer.line_number()
         )
     );
 

--- a/huff_lexer/tests/keywords.rs
+++ b/huff_lexer/tests/keywords.rs
@@ -11,19 +11,19 @@ fn parses_macro_keyword() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span, lexer.line_number()));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span, lexer.line_number()));
 
     // Lastly we should parse the macro keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let macro_span = Span::new(8..12, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Macro, macro_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Macro, macro_span, lexer.line_number()));
 
     lexer.next();
 
@@ -41,19 +41,19 @@ fn parses_fn_keyword() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span, lexer.line_number()));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span, lexer.line_number()));
 
     // Lastly we should parse the fn keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let fn_span = Span::new(8..9, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Fn, fn_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Fn, fn_span, lexer.line_number()));
 
     lexer.next();
 
@@ -71,19 +71,19 @@ fn parses_test_keyword() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span, lexer.line_number()));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span, lexer.line_number()));
 
     // Lastly we should parse the fn keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let test_span = Span::new(8..11, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Test, test_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Test, test_span, lexer.line_number()));
 
     lexer.next();
 
@@ -101,19 +101,19 @@ fn parses_function_keyword() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span, lexer.line_number()));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span, lexer.line_number()));
 
     // Lastly we should parse the function keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let function_span = Span::new(8..15, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Function, function_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Function, function_span, lexer.line_number()));
 
     lexer.next();
 
@@ -131,19 +131,19 @@ fn parses_event_keyword() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span, lexer.line_number()));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span, lexer.line_number()));
 
     // Lastly we should parse the event keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let event_span = Span::new(8..12, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Event, event_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Event, event_span, lexer.line_number()));
 
     let _ = lexer.next(); // whitespace
     let _ = lexer.next(); // event name
@@ -166,19 +166,19 @@ fn parses_constant_keyword() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span, lexer.line_number()));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span, lexer.line_number()));
 
     // Lastly we should parse the constant keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let constant_span = Span::new(8..15, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Constant, constant_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Constant, constant_span, lexer.line_number()));
 
     lexer.next();
 
@@ -207,7 +207,7 @@ fn parses_takes_and_returns_keywords() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let takes_span = Span::new(23..27, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Takes, takes_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Takes, takes_span, lexer.line_number()));
 
     // Lex the middle 5 chars
     let _ = lexer.next(); // whitespace
@@ -220,7 +220,7 @@ fn parses_takes_and_returns_keywords() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let returns_span = Span::new(37..43, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span, lexer.line_number()));
 
     // Lex the last 4 chars
     let _ = lexer.next(); // whitespace
@@ -254,7 +254,7 @@ fn parses_takes_and_returns_keywords_tight_syntax() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let takes_span = Span::new(23..27, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Takes, takes_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Takes, takes_span, lexer.line_number()));
 
     // Lex the next 4 chars
     let _ = lexer.next(); // open parenthesis
@@ -266,7 +266,7 @@ fn parses_takes_and_returns_keywords_tight_syntax() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let returns_span = Span::new(32..38, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span, lexer.line_number()));
 
     // Lex the last 3 chars
     let _ = lexer.next(); // open parenthesis
@@ -296,7 +296,7 @@ fn parses_function_type_keywords() {
     // Lex view first
     let tok = lexer.next().unwrap().unwrap();
     let view_span = Span::new(24..27, None);
-    assert_eq!(tok, Token::new(TokenKind::View, view_span));
+    assert_eq!(tok, Token::new(TokenKind::View, view_span, lexer.line_number()));
 
     // Lex the next 4 chars
     let _ = lexer.next(); // whitespace
@@ -349,7 +349,10 @@ fn parses_function_definition_with_keyword_name() {
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let ident_span = Span::new(17..end_span_s - 1, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::Ident(s.to_string()), ident_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::Ident(s.to_string()), ident_span.clone(), lexer.line_number())
+        );
 
         let _ = lexer.next(); // open parenthesis
         let _ = lexer.next(); // uint256
@@ -362,7 +365,10 @@ fn parses_function_definition_with_keyword_name() {
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let returns_span = Span::new((end_span_s + 15)..(end_span_s + 21), None);
-        assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::Returns, returns_span.clone(), lexer.line_number())
+        );
 
         let _ = lexer.next(); // open parenthesis
         let _ = lexer.next(); // uint256
@@ -413,7 +419,10 @@ fn parses_label_with_keyword_name() {
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let fn_name_span = Span::new(0..s.len() - 1, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::Label(s.to_string()), fn_name_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::Label(s.to_string()), fn_name_span.clone(), lexer.line_number())
+        );
 
         let _ = lexer.next(); // colon
         let _ = lexer.next(); // whitespace
@@ -421,7 +430,14 @@ fn parses_label_with_keyword_name() {
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let fn_name_span = Span::new((s.len() + 14)..(s.len() * 2 + 13), None);
-        assert_eq!(unwrapped, Token::new(TokenKind::Ident(s.to_uppercase()), fn_name_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(
+                TokenKind::Ident(s.to_uppercase()),
+                fn_name_span.clone(),
+                lexer.line_number()
+            )
+        );
 
         let _ = lexer.next(); // open parenthesis
         let _ = lexer.next(); // close parenthesis
@@ -471,7 +487,10 @@ fn parses_function_with_keyword_name() {
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let fn_name_span = Span::new(19..19 + s.len() - 1, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::Ident(s.to_string()), fn_name_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::Ident(s.to_string()), fn_name_span.clone(), lexer.line_number())
+        );
 
         let _ = lexer.next(); // whitespace
         let _ = lexer.next(); // jumpi
@@ -525,7 +544,10 @@ fn parses_function_with_keyword_name_in_macro() {
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let takes_span = Span::new(21..25, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::Macro, takes_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::Macro, takes_span.clone(), lexer.line_number())
+        );
 
         let _ = lexer.next(); // whitespace
         let _ = lexer.next(); // NUMS
@@ -539,7 +561,10 @@ fn parses_function_with_keyword_name_in_macro() {
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let takes_span = Span::new(36..40, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::Takes, takes_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::Takes, takes_span.clone(), lexer.line_number())
+        );
 
         let _ = lexer.next(); // open parenthesis
         let _ = lexer.next(); // 0
@@ -550,7 +575,10 @@ fn parses_function_with_keyword_name_in_macro() {
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let returns_span = Span::new(45..51, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::Returns, returns_span.clone(), lexer.line_number())
+        );
 
         let _ = lexer.next(); // open parenthesis
         let _ = lexer.next(); // 1
@@ -567,7 +595,10 @@ fn parses_function_with_keyword_name_in_macro() {
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let fn_name_span = Span::new(84..84 + s.len() - 1, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::Ident(s.to_string()), fn_name_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::Ident(s.to_string()), fn_name_span.clone(), lexer.line_number())
+        );
 
         let _ = lexer.next(); // whitespace
         let _ = lexer.next(); // }
@@ -601,19 +632,25 @@ fn parses_keyword_arbitrary_whitespace() {
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let define_span = Span::new(0..6, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::Define, define_span.clone(), lexer.line_number())
+        );
 
         // The next token should be the whitespace
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let whitespace_span = Span::new(7..11, None);
-        assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span.clone()));
+        assert_eq!(
+            unwrapped,
+            Token::new(TokenKind::Whitespace, whitespace_span.clone(), lexer.line_number())
+        );
 
         // Lastly we should parse the constant keyword
         let tok = lexer.next();
         let unwrapped = tok.unwrap().unwrap();
         let constant_span = Span::new(12..12 + key.len() - 1, None);
-        assert_eq!(unwrapped, Token::new(kind, constant_span.clone()));
+        assert_eq!(unwrapped, Token::new(kind, constant_span.clone(), lexer.line_number()));
 
         lexer.next();
 
@@ -643,7 +680,7 @@ fn parses_takes_keyword_arbitrary_whitespace() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let takes_span = Span::new(28..32, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Takes, takes_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Takes, takes_span, lexer.line_number()));
 
     // Lex the middle 5 chars
     let _ = lexer.next(); // whitespace
@@ -656,7 +693,7 @@ fn parses_takes_keyword_arbitrary_whitespace() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let returns_span = Span::new(38..44, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Returns, returns_span, lexer.line_number()));
 
     // Lex the last 4 chars
     let _ = lexer.next(); // whitespace

--- a/huff_lexer/tests/numbers.rs
+++ b/huff_lexer/tests/numbers.rs
@@ -9,7 +9,7 @@ fn lexes_zero_prefixed_numbers() {
 
     // The first and only token should be lexed as 0
     let tok = lexer.next().unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::Num(0), Span::new(0..1, None)));
+    assert_eq!(tok, Token::new(TokenKind::Num(0), Span::new(0..1, None), lexer.line_number()));
 
     lexer.next();
 
@@ -25,7 +25,14 @@ fn lexes_large_numbers() {
 
     // The first and only token should be lexed
     let tok = lexer.next().unwrap().unwrap();
-    assert_eq!(tok, Token::new(TokenKind::Num(usize::MAX), Span::new(0..source.len() - 1, None)));
+    assert_eq!(
+        tok,
+        Token::new(
+            TokenKind::Num(usize::MAX),
+            Span::new(0..source.len() - 1, None),
+            lexer.line_number()
+        )
+    );
 
     lexer.next();
 

--- a/huff_lexer/tests/symbols.rs
+++ b/huff_lexer/tests/symbols.rs
@@ -11,25 +11,25 @@ fn lexes_assign_op() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(0..6, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Define, define_span, lexer.line_number()));
 
     // The next token should be the whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let define_span = Span::new(7..7, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, define_span, lexer.line_number()));
 
     // Then we should parse the constant keyword
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let constant_span = Span::new(8..15, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Constant, constant_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Constant, constant_span, lexer.line_number()));
 
     // The next token should be another whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let ws_span = Span::new(16..16, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, ws_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, ws_span, lexer.line_number()));
 
     // Then we should get the function name
     let tok = lexer.next();
@@ -37,20 +37,24 @@ fn lexes_assign_op() {
     let function_span = Span::new(17..40, None);
     assert_eq!(
         unwrapped,
-        Token::new(TokenKind::Ident("TRANSFER_EVENT_SIGNATURE".to_string()), function_span)
+        Token::new(
+            TokenKind::Ident("TRANSFER_EVENT_SIGNATURE".to_string()),
+            function_span,
+            lexer.line_number()
+        )
     );
 
     // Then we should have another whitespace
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let whitespace_span = Span::new(41..41, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Whitespace, whitespace_span, lexer.line_number()));
 
     // Finally, we have our assign operator
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let assign_span = Span::new(42..42, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Assign, assign_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Assign, assign_span, lexer.line_number()));
     lexer.next();
 
     // We covered the whole source
@@ -67,7 +71,7 @@ fn lexes_brackets() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let bracket_span = Span::new(0..0, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::OpenBracket, bracket_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::OpenBracket, bracket_span, lexer.line_number()));
 
     // The next token should be the location identifier
     let tok = lexer.next();
@@ -75,14 +79,18 @@ fn lexes_brackets() {
     let loc_span = Span::new(1..21, None);
     assert_eq!(
         unwrapped,
-        Token::new(TokenKind::Ident("TOTAL_SUPPLY_LOCATION".to_string()), loc_span)
+        Token::new(
+            TokenKind::Ident("TOTAL_SUPPLY_LOCATION".to_string()),
+            loc_span,
+            lexer.line_number()
+        )
     );
 
     // Then we should parse the closing bracket
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let bracket_span = Span::new(22..22, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::CloseBracket, bracket_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::CloseBracket, bracket_span, lexer.line_number()));
 
     // Eat the last tokens
     let _ = lexer.next(); // whitespace
@@ -133,7 +141,7 @@ fn lexes_braces() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let brace_span = Span::new(51..51, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::OpenBrace, brace_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::OpenBrace, brace_span, lexer.line_number()));
 
     // Eat the characters in between braces
     let _ = lexer.next(); // whitespace
@@ -148,7 +156,7 @@ fn lexes_braces() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let brace_span = Span::new(131..131, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::CloseBrace, brace_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::CloseBrace, brace_span, lexer.line_number()));
 
     // Eat the last whitespace
     let _ = lexer.next(); // whitespace
@@ -173,7 +181,7 @@ fn lexes_math_ops() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let add_span = Span::new(4..4, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Add, add_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Add, add_span, lexer.line_number()));
 
     // Eat the number and whitespaces
     let _ = lexer.next();
@@ -184,7 +192,7 @@ fn lexes_math_ops() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let sub_span = Span::new(9..9, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Sub, sub_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Sub, sub_span, lexer.line_number()));
 
     // Eat the number and whitespaces
     let _ = lexer.next();
@@ -195,7 +203,7 @@ fn lexes_math_ops() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let mul_span = Span::new(14..14, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Mul, mul_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Mul, mul_span, lexer.line_number()));
 
     // Eat the number and whitespace
     let _ = lexer.next();
@@ -206,7 +214,7 @@ fn lexes_math_ops() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let div_span = Span::new(18..18, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Div, div_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Div, div_span, lexer.line_number()));
 
     // Eat the number and whitespace
     let _ = lexer.next();
@@ -229,7 +237,7 @@ fn lexes_commas() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let comma_span = Span::new(4..4, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Comma, comma_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Comma, comma_span, lexer.line_number()));
 
     // Eat alphanumerics
     let _ = lexer.next();
@@ -252,7 +260,7 @@ fn lexes_comma_sparse() {
     let tok = lexer.next();
     let unwrapped = tok.unwrap().unwrap();
     let comma_span = Span::new(5..5, None);
-    assert_eq!(unwrapped, Token::new(TokenKind::Comma, comma_span));
+    assert_eq!(unwrapped, Token::new(TokenKind::Comma, comma_span, lexer.line_number()));
 
     let _ = lexer.next(); // whitespace
     let _ = lexer.next(); // alphanumerics

--- a/huff_utils/src/token.rs
+++ b/huff_utils/src/token.rs
@@ -10,12 +10,14 @@ pub struct Token {
     pub kind: TokenKind,
     /// An associated Span
     pub span: Span,
+    /// Line number of token
+    pub line_number: usize,
 }
 
 impl Token {
     /// Public associated function that instantiates a Token.
-    pub fn new(kind: TokenKind, span: Span) -> Self {
-        Self { kind, span }
+    pub fn new(kind: TokenKind, span: Span, line_number: usize) -> Self {
+        Self { kind, span, line_number }
     }
 }
 
@@ -133,13 +135,18 @@ pub enum TokenKind {
 
 impl TokenKind {
     /// Transform a single char TokenKind into a Token given a single position
-    pub fn into_single_span(self, position: u32) -> Token {
-        self.into_span(position, position)
+    pub fn into_single_span(self, position: u32, line_number: usize) -> Token {
+        self.into_span(position, position, line_number)
     }
 
     /// Transform a TokenKind into a Token given a start and end position
-    pub fn into_span(self, start: u32, end: u32) -> Token {
-        Token { kind: self, span: Span { start: start as usize, end: end as usize, file: None } }
+    /// TODO: Probably should rename into_token
+    pub fn into_span(self, start: u32, end: u32, line_number: usize) -> Token {
+        Token {
+            kind: self,
+            span: Span { start: start as usize, end: end as usize, file: None },
+            line_number,
+        }
     }
 }
 
@@ -190,7 +197,7 @@ impl fmt::Display for TokenKind {
                 for b in l.iter() {
                     let _ = write!(&mut s, "{b:02x}");
                 }
-                return write!(f, "{s}");
+                return write!(f, "{s}")
             }
             TokenKind::Opcode(o) => return write!(f, "{o}"),
             TokenKind::Label(s) => return write!(f, "{s}"),
@@ -201,7 +208,7 @@ impl fmt::Display for TokenKind {
                     let brackets = if size > &0 { format!("[{size}]") } else { "[]".to_string() };
                     s.push_str(&brackets);
                 }
-                return write!(f, "{pt}{s}");
+                return write!(f, "{pt}{s}")
             }
             TokenKind::JumpTable => "jumptable",
             TokenKind::JumpTablePacked => "jumptable__packed",


### PR DESCRIPTION
Added line number to Lexer struct and check for new line in iterable tokens in huff_cli.
Breaks lexer tests as of now