### PR TITLE
Add input argument to cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,42 +190,43 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
- "atty",
- "bitflags",
+ "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.3",
- "once_cell",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "codemap"
@@ -195,6 +244,12 @@ dependencies = [
  "codemap",
  "termcolor",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "comfy-table"
@@ -487,12 +542,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
@@ -616,22 +665,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -792,12 +831,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "parity-scale-codec"
@@ -1393,12 +1426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,7 +1485,7 @@ version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -1545,6 +1572,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/huff_cli/Cargo.toml
+++ b/huff_cli/Cargo.toml
@@ -12,7 +12,7 @@ Huff Language Compiler built in Pure Rust.
 keywords = ["huff", "rust", "evm", "bytecode", "compiler"]
 
 [dependencies]
-clap = { version = "3.1.18", features = ["derive"] }
+clap = { version = "4.4.6", features = ["derive"] }
 huff_utils = { path = "../huff_utils", version = "0.x.x" }
 huff_lexer = { path = "../huff_lexer", version = "0.x.x" }
 comfy-table = "6.0.0"

--- a/huff_cli/examples/METH_WETH.huff
+++ b/huff_cli/examples/METH_WETH.huff
@@ -1,0 +1,1234 @@
+#include "./interfaces/IMETH.huff"
+
+////////////////////////////////////////////////////////////////
+//             SELECTOR SWITCH CONSTANTS                      //
+////////////////////////////////////////////////////////////////
+/// @dev Right bit shift that retrieves the unique upper bits of all selectors contained within the ABI.
+#define constant S_SHIFT = 0x12 // 18
+#define constant S_COVER = 0x3f // 63 (111111_2)
+
+////////////////////////////////////////////////////////////////
+//                 METADATA CONSTANTS                         //
+////////////////////////////////////////////////////////////////
+// ================== Decimals ===================
+/// @dev METH has 18 decimals meaning a balance of `1150100000000000000` should be displayed as `1.1501`.
+#define constant DECIMALS_OFFSET = 0xc8d
+#define constant METH_DECIMALS = 0x12
+// ==================== Name =====================
+#define constant MAX_NAME_LEN = 0x40
+#define constant NAME_OFFSET = 0x40e1
+#define constant NAME_ENCODED_OFFSET = 0x20
+#define table NAME_DATA {
+  0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000214d6178696d616c6c7920456666696369656e74205772617070656420457468657200000000000000000000000000000000000000000000000000000000000000
+}
+// =================== Symbol ====================
+#define constant MAX_SYMBOL_LEN = 0x1f
+#define constant SYMBOL_OFFSET = 0x2591
+// symbol.length ++ "METH"
+#define constant PACKED_SYMBOL = 0x044d455448000000000000000000000000000000000000000000000000000000
+
+// 1 (padding) + 1 (decimals) + 32 (packed symbol) + 128 (abi-encoded name)
+#define constant METADATA_SRC_SIZE = 0xa2 
+
+////////////////////////////////////////////////////////////////
+//                      OTHER CONSTANTS                       //
+////////////////////////////////////////////////////////////////
+/// @dev The only special privileges the recovery address should have is the ability to sweep funds from the zero and `this` addresses.
+#define constant LOST_N_FOUND = 0x1212121212121212121212121212121212121212
+
+////////////////////////////////////////////////////////////////
+//                       UTILITY MACROS                       //
+////////////////////////////////////////////////////////////////
+
+/**
+ * @dev Acts as an alias to `lt(a, b)`. Equivalent but more efficient to `and(iszero(a), b)`.
+ * @param:stack a Value that must be zero for the expression to be true, can be any non-zero value.
+ * @param:stack b Value that must be 0x1 for the expression to be true. Can lead to invalid results
+ * if not a lone bit.
+ * @return:stack res A 0 or 1 depending on whether the expression is true.
+ */
+#define macro _NOTA_AND_B() = takes(2) returns(1) {
+    // takes:          [b, a]
+
+    // Need (A == 0)  &&   B:
+    //         [=0]   LT  [0] -> 0
+    //         [=0]   LT  [1] -> 1
+    //         [>0]   LT  [0] -> 0
+    //         [>0]   LT  [1] -> 0
+
+    lt              // [!a && b]
+    // returns:        [res]
+}
+
+#define macro _REQUIRE_NOT() = takes(1) returns(0) {
+    // takes:              [has_error]
+    /// @dev Use literal instead of label (Huff doesn't support 1-byte pushes for labels yet)
+    0x7f jumpi          // []
+    // returns:            []
+}
+
+#define macro _REVERT() = takes(0) returns(0) {
+    returndatasize       // [0]
+    returndatasize       // [0, 0]
+    revert               // [] -- end
+}
+
+/**
+ * @dev Pushes a sanitized address from calldata to the stack.
+ * @param:stack addr_offset The parameters offset in calldata (`0x10 + param_index * 0x20`)
+ * @return:stack addr The sanitized address.
+ */
+#define macro _LOAD_ADDRESS() = takes(1) returns(1) {
+    // takes:             [addr_offset]
+    calldataload       // [shifted_addr]
+    0x60               // [shifted_addr, 96]
+    shr                // [addr]
+    // returns:        // [addr]
+}
+
+/**
+ * @dev Determines whether the given `allowance` is "practically infinite".
+ * @param:stack allowance An allowance as a full EVM word.
+ * @param:macro z0 1-byte zero pushing opcode.
+ * @return:stack is_infinite Whether the given `allowance` is practically infinite. 0 if false,
+ * non-zero value in the range [1, 255] if true.
+ */
+#define macro _IS_INF(z0) = takes(1) returns(1) {
+    // takes:      [allowance]
+    <z0>        // [allowance, 0]
+    byte        // [is_infinite]
+    // returns:    [is_infinite]
+}
+
+#define macro _RETURN_WORD(z0, word_size) = takes(1) returns(0) {
+    // takes:      [x]
+    <z0>        // [x, 0] 
+    mstore      // []
+    <word_size> // [32]
+    <z0>        // [32, 0]
+    return      // []
+}
+
+#define macro _SEND_ETH(z0) = takes(6) returns(0) {
+    // takes:                [0, 0, 0, 0, amount, recipient]
+    gas                   // [0, 0, 0, 0, amount, recipient, gas]
+    call                  // [success]
+    no_revert jumpi       // []
+        returndatasize    // [rdz]
+        <z0> <z0>         // [rdz, 0, 0]
+        returndatacopy    // []
+        returndatasize    // [rdz]
+        <z0>              // [rdz, 0]
+        revert            // [] -- end
+    no_revert:            // []
+    // Stop in `_SEND_ETH` macro to ensure CEI.
+        stop              // [] -- end
+}
+
+////////////////////////////////////////////////////////////////
+//                       EVENT HELPERS                        //
+////////////////////////////////////////////////////////////////
+
+#define macro _EMIT_TRANSFER(z0, word_size) = takes(3) returns(0) {
+    // takes:                 [to, from, amount]
+    <z0>                   // [to, from, amount, 0]
+    mstore                 // [to, from]
+    __EVENT_HASH(Transfer) // [to, from, Transfer.sig]
+    <word_size>            // [to, from, Transfer.sig, 32]
+    <z0>                   // [to, from, Transfer.sig, 32, 0]
+    log3                   // []
+    // returns:               []
+}
+
+#define macro _EMIT_DEPOSIT(z0) = takes(1) returns(0) {
+    // takes:                 [to]
+    callvalue              // [to, callvalue]
+    <z0>                   // [to, callvalue, 0]
+    mstore                 // [to]
+    __EVENT_HASH(Deposit)  // [to, Deposit.sig]
+    0x10                   // [to, Deposit.sig, 16]
+    dup1                   // [to, Deposit.sig, 16, 16]
+    log2                   // []
+    // returns:               []
+}
+
+#define macro _EMIT_WITHDRAWAL(z0) = takes(2) returns(0) {
+    // takes:                   [from, amount]
+    <z0>                     // [from, amount, 0]
+    mstore                   // [from]
+    __EVENT_HASH(Withdrawal) // [from, Withdrawal.sig]
+    0x10                     // [from, Withdrawal.sig, 16]
+    dup1                     // [from, Withdrawal.sig, 16, 16]
+    log2                     // []
+    // returns:                 []
+}
+
+#define macro _SWEEP_LOG3(z0) = takes(4) returns(0) {
+    // takes:    [indexed_arg2, indexed_arg1, event_hash, amount]
+    <z0>      // [indexed_arg2, indexed_arg1, event_hash, amount, 0]
+    mstore    // [indexed_arg2, indexed_arg1, event_hash]
+    msize     // [indexed_arg2, indexed_arg1, event_hash, 32]
+    <z0>      // [indexed_arg2, indexed_arg1, event_hash, 32, 0]
+    log3      // []
+    // returns:  []
+}
+
+
+////////////////////////////////////////////////////////////////
+//                  REUSABLE FUNCTION MACROS                  //
+////////////////////////////////////////////////////////////////
+
+
+#define macro _TRANSFER(z0, word_size) = takes(6) returns(0) {
+    // takes:             [has_error, from, amount, to, amount, from]
+    // -- Update `from` Balance.
+    sload              // [has_error, from, amount, to, amount, from.bal]
+    dup3               // [has_error, from, amount, to, amount, from.bal, to]
+    swap6              // [to,        from, amount, to, amount, from.bal, has_error]
+    dup2               // [to,        from, amount, to, amount, from.bal, has_error, from.bal]
+    dup4               // [to,        from, amount, to, amount, from.bal, has_error, from.bal, amount]
+    gt                 // [to,        from, amount, to, amount, from.bal, has_error, amount > from.bal]
+    or                 // [to,        from, amount, to, amount, from.bal, has_error']
+    empty_revert jumpi // [to,        from, amount, to, amount, from.bal]
+    sub                // [to,        from, amount, to, from.bal']
+    dup4               // [to,        from, amount, to, from.bal', from]
+    sstore             // [to,        from, amount, to]
+    // -- Update `to` Balance.
+    sload              // [to,        from, amount, to.bal]
+    dup2               // [to,        from, amount, to.bal, amount]
+    add                // [to,        from, amount, to.bal']
+    dup4               // [to,        from, amount, to.bal', to]
+    sstore             // [to,        from, amount]
+    _EMIT_TRANSFER(<z0>, <word_size>)
+    //                    []
+    // returns:           []
+}
+
+#define macro _WITHDRAW_ALL(z0) = takes(0) returns(1) {
+    // takes:                 []
+    // -- Update balance.
+    caller                 // [caller]
+    sload                  // [caller.bal]
+    <z0>                   // [caller.bal, 0]
+    caller                 // [caller.bal, 0, caller]
+    sstore                 // [caller.bal]
+    // -- Emit event.
+    caller                 // [caller.bal, caller]
+    dup2                   // [caller.bal, caller, caller.bal]
+    _EMIT_WITHDRAWAL(<z0>) // [caller.bal]
+    // returns:               [caller.bal]
+}
+
+/// @dev Expects msize to be 0-1 words.
+#define macro _APPROVE(z0) = takes(0) returns(0) {
+    0x24 calldataload      // [amount]
+    0x10 _LOAD_ADDRESS()   // [amount, spender]
+
+    // -- Emit Event.
+    dup2                   // [amount, spender, amount]
+    <z0>                   // [amount, spender, amount, 0]
+    mstore                 // [amount, spender]
+    dup1                   // [amount, spender, spender]
+    caller                 // [amount, spender, spender, caller]
+    __EVENT_HASH(Approval) // [amount, spender, spender, caller, Approval.sig]
+    msize                  // [amount, spender, spender, caller, Approval.sig, 32]
+    <z0>                   // [amount, spender, spender, caller, Approval.sig, 32, 0]
+    log3                   // [amount, spender]
+
+    // -- Get Allowance Slot.
+    caller                 // [amount, spender, caller]
+    <z0>                   // [amount, spender, caller, 0]
+    mstore                 // [amount, spender]
+    msize                  // [amount, spender, 32]
+    mstore                 // [amount]
+    msize                  // [amount, 64]
+    <z0>                   // [amount, 64, 0]
+    sha3                   // [amount, allowance_slot]
+    // -- Update Allowance.
+    sstore                 // []
+}
+
+#define macro _DEPOSIT(z0) = takes(0) returns(0) {
+    // takes:     []
+    caller     // [caller]
+    sload      // [caller.bal]
+    callvalue  // [caller.bal, callvalue]
+    add        // [caller_bal']
+    caller     // [caller_bal', caller]
+    sstore     // []
+    caller     // [caller]
+    _EMIT_DEPOSIT(<z0>)
+    //            []
+    // returns:   []
+}
+
+#define macro _BURN_FROM_CALLER(z0) = takes(5) returns(5) {
+    // takes:             [has_error, 0, 0, 0, amount]
+    dup1               // [has_error, 0, 0, 0, amount, amount]
+    caller             // [has_error, 0, 0, 0, amount, amount, caller]
+    sload              // [has_error, 0, 0, 0, amount, amount, caller.bal]
+    <z0>               // [has_error, 0, 0, 0, amount, amount, caller.bal, 0]
+    swap7              // [0, 0, 0, 0, amount, amount, caller.bal, has_error]
+    dup2               // [0, 0, 0, 0, amount, amount, caller.bal, has_error, caller.bal]
+    dup4               // [0, 0, 0, 0, amount, amount, caller.bal, has_error, caller.bal, amount]
+    gt                 // [0, 0, 0, 0, amount, amount, caller.bal, has_error, amount > caller.bal]
+    or                 // [0, 0, 0, 0, amount, amount, caller.bal, has_error']
+    empty_revert jumpi // [0, 0, 0, 0, amount, amount, caller.bal]
+    sub                // [0, 0, 0, 0, amount, caller.bal']
+    caller             // [0, 0, 0, 0, amount, caller.bal', caller]
+    sstore             // [0, 0, 0, 0, amount]
+    caller             // [0, 0, 0, 0, amount, caller]
+    dup2               // [0, 0, 0, 0, amount, caller, amount]
+    _EMIT_WITHDRAWAL(<z0>)
+    //                    [0, 0, 0, 0, amount]
+    // returns:           [0, 0, 0, 0, amount]
+}
+
+/**
+ * @dev Determines the allowance slot for `(from, caller)` and loads the allowance. Jumps to
+ * `inf_allow_dest` if the allowance is infinite. Expects msize to be 0-1 words.
+ */
+#define macro _GET_ALLOWANCE(z0, inf_allow_dest) = takes(1) returns(2) {
+    // takes:                 [from]
+
+    // -- Calculate allowance slot.
+    <z0>                   // [from, 0]
+    mstore                 // []
+    caller                 // [caller]
+    msize                  // [caller, 32]
+    mstore                 // []
+    msize                  // [64]
+    <z0>                   // [64, 0]
+    sha3                   // [allowance_slot]
+    // -- Load allowance.
+    dup1                   // [allowance_slot, allowance_slot]
+    sload                  // [allowance_slot, allowance]
+    // -- Check infinite.
+    dup1                   // [allowance_slot, allowance, allowance]
+    _IS_INF(<z0>)          // [allowance_slot, allowance, allowance_infinite]
+    <inf_allow_dest> jumpi // [allowance_slot, allowance]
+    // returns:               [allowance_slot, allowance]
+}
+
+////////////////////////////////////////////////////////////////
+//                      METADATA METHODS                      //
+////////////////////////////////////////////////////////////////
+
+#define macro NAME(z0) = takes(0) returns(0) {
+    __tablesize(NAME_DATA)  // [name_data.size]
+    __tablestart(NAME_DATA) // [name_data.size, name_data.offset]
+    <z0>                    // [name_data.size, name_data.offset, 0]
+    codecopy                // []
+    msize                   // [ret_size]
+    <z0>                    // [ret_size, 0]
+    return                  // [] -- end
+}
+
+#define macro SYMBOL(z0) = takes(0) returns(0) {
+    0x20             // [32]
+    <z0>             // [32, 0]
+    mstore           // []
+    [PACKED_SYMBOL]  // [packed_symbol]
+    0x3f             // [packed_symbol, 63]
+    mstore           // []
+    msize            // [ret_size]
+    <z0>             // [ret_size, 0]
+    return           // [] -- end
+}
+
+#define macro DECIMALS(z0) = takes(0) returns(0) {
+    [METH_DECIMALS]           // [decimals]
+    _RETURN_WORD(<z0>, msize) // [] -- end
+}
+
+////////////////////////////////////////////////////////////////
+//                        VIEW METHODS                        //
+////////////////////////////////////////////////////////////////
+
+#define macro TOTAL_SUPPLY(z0) = takes(0) returns(0) {
+    selfbalance               // [this.balance]
+    _RETURN_WORD(<z0>, msize) // [] -- end
+}
+
+#define macro BALANCE_OF(z0) = takes(0) returns(0) {
+    0x10 _LOAD_ADDRESS()      // [account]
+    sload                     // [account.bal]
+    _RETURN_WORD(<z0>, msize) // [] -- end
+}
+
+#define macro ALLOWANCE(z0) = takes(0) returns(0) {
+    0x34               // [52]
+    // Copying from start of address intead of zero to mitigate risk of dirty address resulting in
+    // valid address.
+    0x10               // [52, 16]
+    0x0c               // [52, 16, 12]
+    calldatacopy       // []
+    msize              // [64]
+    <z0>               // [64, 0]
+    sha3               // [allowance_slot]
+    sload              // [allowance]
+    <z0>               // [allowance, 0]
+    mstore             // []
+    0x20               // [32]
+    <z0>               // [32, 0]
+    return             // [] -- end
+}
+
+////////////////////////////////////////////////////////////////
+//                     ERC20 CORE METHODS                     //
+////////////////////////////////////////////////////////////////
+
+#define macro TRANSFER(z0) = takes(1) returns(0) {
+    // takes:                 [has_error]
+    caller                 // [has_error, caller]
+    0x24 calldataload      // [has_error, caller, amount]
+    0x10 _LOAD_ADDRESS()   // [has_error, caller, amount, to]
+    dup2                   // [has_error, caller, amount, to, amount]
+    caller                 // [has_error, caller, amount, to, amount, caller]
+    _TRANSFER(<z0>, msize) // []
+    stop                   // [] -- end
+}
+
+#define macro _TRANSFER_FROM_END(z0) = takes(4) returns(0) {
+    // takes:                 [has_error, from, amount, to]
+    dup2                   // [has_error, from, amount, to, amount]
+    dup4                   // [has_error, from, amount, to, amount, from]
+    _TRANSFER(<z0>, 0x20)  // []
+    stop                   // [] -- end
+}
+
+
+/// @dev Macro should not be reachable.
+#define macro _TRANSFER_FROM_INF_END(z0) = takes(0) returns(0) {
+    transferFrom_inf_allow:      // [has_error, from, amount, to, _, _]
+        pop pop                  // [has_error, from, amount, to]
+        _TRANSFER_FROM_END(<z0>) // [] -- end
+}
+
+#define macro TRANSFER_FROM(z0) = takes(1) returns(0) {
+    // takes:                   [has_error]
+    0x10 _LOAD_ADDRESS()     // [has_error, from]
+    0x44 calldataload        // [has_error, from, amount]
+    0x30 _LOAD_ADDRESS()     // [has_error, from, amount, to]
+    // -- Get allowance slot & load.
+    dup3                     // [has_error, from, amount, to, from]
+    _GET_ALLOWANCE(<z0>, transferFrom_inf_allow)
+    //                       [has_error, from, amount, to, allowance_slot, allowance]
+    // -- Check sufficient allowance.
+    swap5                    // [allowance, from, amount, to, allowance_slot, has_error]
+    dup6                     // [allowance, from, amount, to, allowance_slot, has_error, allowance]
+    dup5                     // [allowance, from, amount, to, allowance_slot, has_error, allowance, amount]
+    gt                       // [allowance, from, amount, to, allowance_slot, has_error, amount > allowance]
+    or                       // [allowance, from, amount, to, allowance_slot, has_error']
+    swap5                    // [has_error, from, amount, to, allowance_slot, allowance]
+    // -- Update allowance.
+    dup4                     // [has_error, from, amount, to, allowance_slot, allowance, amount]
+    swap1                    // [has_error, from, amount, to, allowance_slot, amount, allowance]
+    sub                      // [has_error, from, amount, to, allowance_slot, allowance']
+    swap1                    // [has_error, from, amount, to, allowance', allowance_slot]
+    sstore                   // [has_error, from, amount, to]
+    _TRANSFER_FROM_END(<z0>) // [] -- end
+}
+
+#define macro APPROVE(z0) = takes(0) returns(0) {
+    _APPROVE(<z0>)  // []
+    stop            // [] -- end
+}
+
+////////////////////////////////////////////////////////////////
+//               DEPOSIT (AKA WRAPPING) METHODS               //
+////////////////////////////////////////////////////////////////
+
+#define macro DEPOSIT(z0) = takes(0) returns(0) {
+    _DEPOSIT(<z0>)        // []
+    stop                  // [] -- end
+}
+
+#define macro DEPOSIT_TO(z0) = takes(0) returns(0) {
+    // takes:                     []
+    0x10 _LOAD_ADDRESS()       // [to]
+    dup1                       // [to, to]
+    sload                      // [to, to.bal]
+    callvalue                  // [to, to.bal, callvalue]
+    add                        // [to, to.bal']
+    dup2                       // [to, to.bal', to]
+    sstore                     // [to]
+    _EMIT_DEPOSIT(<z0>)        // []
+    stop                       // [] -- end
+}
+
+#define macro DEPOSIT_AND_APPROVE(z0) = takes(0) returns(0) {
+    _DEPOSIT(<z0>)        // []
+    _APPROVE(<z0>)        // []
+    stop                  // [] -- end
+}
+
+////////////////////////////////////////////////////////////////
+//             WITHDRAW (AKA UNWRAPPING) METHODS              //
+////////////////////////////////////////////////////////////////
+
+#define macro WITHDRAW(z0) = takes(1) returns(0) {
+    // takes:                  [has_error]
+    <z0> <z0> <z0>          // [has_error, 0, 0, 0]
+    0x04 calldataload       // [has_error, 0, 0, 0, amount]
+    _BURN_FROM_CALLER(<z0>) // [0, 0, 0, 0, amount]
+    caller                  // [0, 0, 0, 0, amount, caller]
+    _SEND_ETH(<z0>)         // [] -- end
+}
+
+#define macro WITHDRAW_TO(z0) = takes(1) returns(0) {
+    // takes:                  [has_error]
+    <z0> <z0> <z0>          // [has_error, 0, 0, 0]
+    0x24 calldataload       // [has_error, 0, 0, 0, amount]
+    _BURN_FROM_CALLER(<z0>) // [0, 0, 0, 0, amount]
+    0x04 calldataload       // [0, 0, 0, 0, amount, to]
+    _SEND_ETH(<z0>)         // [] -- end
+}
+
+#define macro WITHDRAW_ALL(z0) = takes(0) returns(0) {
+    // takes:                  []
+    <z0> <z0> <z0> <z0>     // [0, 0, 0, 0]
+    _WITHDRAW_ALL(<z0>)     // [0, 0, 0, 0, amount]
+    caller                  // [0, 0, 0, 0, amount, caller]
+    _SEND_ETH(<z0>)         // []
+}
+
+#define macro WITHDRAW_ALL_TO(z0) = takes(0) returns(0) {
+    // takes:                  []
+    // Push zeros before to avoid swaps later.
+    <z0> <z0> <z0> <z0>     // [0, 0, 0, 0]
+    _WITHDRAW_ALL(<z0>)     // [0, 0, 0, 0, amount]
+    0x04 calldataload       // [0, 0, 0, 0, amount, to]
+    _SEND_ETH(<z0>)         // []
+}
+
+#define macro _WITHDRAW_FROM_BAL_CHECK(z0) = takes(6) returns(0) {
+    // takes:                      [no_error, 0, 0, 0, amount, from]
+    dup1                        // [no_error, 0, 0, 0, amount, from, from]
+    sload                       // [no_error, 0, 0, 0, amount, from, from_bal]
+    swap6                       // [from_bal, 0, 0, 0, amount, from, no_error]
+    dup7                        // [from_bal, 0, 0, 0, amount, from, no_error, from_bal]
+    dup4                        // [from_bal, 0, 0, 0, amount, from, no_error, from_bal, amount]
+    gt                          // [from_bal, 0, 0, 0, amount, from, no_error, amount > from_bal]
+    _NOTA_AND_B()               // [from_bal, 0, 0, 0, amount, from, no_error']
+    complete_withdrawFrom jumpi // [from_bal, 0, 0, 0, amount, from]
+    <z0> <z0>                   // [from_bal, 0, 0, 0, amount, from, 0, 0]
+    revert                      // [from_bal, 0, 0, 0, amount, from]
+}
+
+#define macro _WITHDRAW_FROM_START(z0) = takes(1) returns(0) {
+    // takes:                         [no_error]
+
+    // -- Initial stack setup and param load.
+    <z0> <z0> <z0>                 // [no_error, 0, 0, 0]
+    0x24 calldataload              // [no_error, 0, 0, 0, amount]
+    0x10 _LOAD_ADDRESS()           // [no_error, 0, 0, 0, amount, from]
+    dup1                           // [no_error, 0, 0, 0, amount, from, from]
+    // -- Allowance load (branches to `withdrawFrom_inf_allow` if allowance infinite).
+    _GET_ALLOWANCE(<z0>, withdrawFrom_inf_allow)
+    //                                [no_error,  0, 0, 0, amount, from, allowance_slot, allowance]
+    // -- Check allowance (continues here if allowance finite).
+    swap7                          // [allowance, 0, 0, 0, amount, from, allowance_slot, no_error]
+    dup8                           // [allowance, 0, 0, 0, amount, from, allowance_slot, no_error, allowance]
+    dup5                           // [allowance, 0, 0, 0, amount, from, allowance_slot, no_error, allowance, amount]
+    gt                             // [allowance, 0, 0, 0, amount, from, allowance_slot, no_error, amount > allowance]
+    _NOTA_AND_B()                  // [allowance, 0, 0, 0, amount, from, allowance_slot, no_error']
+    swap7                          // [no_error', 0, 0, 0, amount, from, allowance_slot, allowance]
+    // -- Update allowance.
+    dup4                           // [no_error', 0, 0, 0, amount, from, allowance_slot, allowance, amount]
+    swap1                          // [no_error', 0, 0, 0, amount, from, allowance_slot, amount, allowance]
+    sub                            // [no_error', 0, 0, 0, amount, from, allowance_slot, allowance']
+    swap1                          // [no_error', 0, 0, 0, amount, from, allowance', allowance_slot]
+    sstore                         // [no_error', 0, 0, 0, amount, from]
+    _WITHDRAW_FROM_BAL_CHECK(<z0>) // [] -- end
+}
+
+#define macro _WITHDRAW_FROM_END(z0) = takes(0) returns(0) {
+    withdrawFrom_inf_allow:            // [no_error, 0, 0, 0, amount, from, allowance_slot, allowance]
+        pop pop                        // [no_error, 0, 0, 0, amount, from]
+        _WITHDRAW_FROM_BAL_CHECK(<z0>) // [] -- end
+    complete_withdrawFrom:             // [from.bal, 0, 0, 0, amount, from]
+        // -- Update balance.
+        dup2                           // [from.bal, 0, 0, 0, amount, from, amount]
+        <z0>                           // [from.bal, 0, 0, 0, amount, from, amount, 0]
+        swap7                          // [0,        0, 0, 0, amount, from, amount, from.bal]
+        sub                            // [0,        0, 0, 0, amount, from, from.bal']
+        dup2                           // [0,        0, 0, 0, amount, from, from.bal', from]
+        sstore                         // [0,        0, 0, 0, amount, from]
+        dup2                           // [0,        0, 0, 0, amount, from, amount]
+        _EMIT_WITHDRAWAL(<z0>)         // [0,        0, 0, 0, amount]
+        caller                         // [0,        0, 0, 0, amount, caller]
+        _SEND_ETH(<z0>)                // [] -- end
+}
+
+#define macro _WITHDRAW_FROM_TO_END(z0) = takes(6) returns(0) {
+    // takes:                       [has_error, 0, 0, 0, amount, from]
+    dup1                         // [has_error, 0, 0, 0, amount, from, from]
+    sload                        // [has_error, 0, 0, 0, amount, from, from.bal]
+    swap6                        // [from.bal,  0, 0, 0, amount, from, has_error]
+    dup7                         // [from.bal,  0, 0, 0, amount, from, has_error, from.bal]
+    dup4                         // [from.bal,  0, 0, 0, amount, from, has_error, from.bal, amount]
+    gt                           // [from.bal,  0, 0, 0, amount, from, has_error, amount > from.bal]
+    or                           // [from.bal,  0, 0, 0, amount, from, has_error']
+    empty_revert jumpi           // [from.bal,  0, 0, 0, amount, from]
+    dup2                         // [from.bal,  0, 0, 0, amount, from, amount]
+    <z0>                         // [from.bal,  0, 0, 0, amount, from, amount, 0]
+    swap7                        // [0,         0, 0, 0, amount, from, amount, from.bal]
+    sub                          // [0,         0, 0, 0, amount, from, from.bal']
+    dup2                         // [0,         0, 0, 0, amount, from, from.bal', from]
+    sstore                       // [0,         0, 0, 0, amount, from]
+    dup2                         // [0,         0, 0, 0, amount, from, amount]
+    _EMIT_WITHDRAWAL(<z0>)       // [0,         0, 0, 0, amount]
+    0x24 calldataload            // [0,         0, 0, 0, amount, to]
+    _SEND_ETH(<z0>)              // [] -- end
+}
+
+#define macro _WITHDRAW_FROM_TO_INF_END(z0) = takes(7) returns(0) {
+    withdrawFromTo_inf_allow:       // [has_error, 0, 0, 0, amount, from, allowance_slot, allowance]
+        pop pop                     // [has_error, 0, 0, 0, amount, from]
+        _WITHDRAW_FROM_TO_END(<z0>) // [] -- end
+}
+
+#define macro WITHDRAW_FROM_TO(z0) = takes(1) returns(0) {
+    // takes:                      [has_error]
+    // -- Initial stack setup.
+    <z0> <z0> <z0>              // [has_error, 0, 0, 0]
+    0x44 calldataload           // [has_error, 0, 0, 0, amount]
+    0x10 _LOAD_ADDRESS()        // [has_error, 0, 0, 0, amount, from]
+    dup1                        // [has_error, 0, 0, 0, amount, from, from]
+    // -- Allowance load & check.
+    _GET_ALLOWANCE(<z0>, withdrawFromTo_inf_allow)
+    //                             [has_error, 0, 0, 0, amount, from, allowance_slot, allowance]
+    swap7                       // [allowance, 0, 0, 0, amount, from, allowance_slot, has_error]
+    dup8                        // [allowance, 0, 0, 0, amount, from, allowance_slot, has_error, allowance]
+    dup5                        // [allowance, 0, 0, 0, amount, from, allowance_slot, has_error, allowance, amount]
+    gt                          // [allowance, 0, 0, 0, amount, from, allowance_slot, has_error, amount > allowance]
+    or                          // [allowance, 0, 0, 0, amount, from, allowance_slot, has_error']
+    swap7                       // [has_error, 0, 0, 0, amount, from, allowance_slot, allowance]
+    // -- Update allowance.
+    dup4                        // [has_error, 0, 0, 0, amount, from, allowance_slot, allowance, amount]
+    swap1                       // [has_error, 0, 0, 0, amount, from, allowance_slot, amount, allowance]
+    sub                         // [has_error, 0, 0, 0, amount, from, allowance_slot, allowance']
+    swap1                       // [has_error, 0, 0, 0, amount, from, allowance', allowance_slot]
+    sstore                      // [has_error, 0, 0, 0, amount, from]
+    _WITHDRAW_FROM_TO_END(<z0>) // -- end
+}
+
+////////////////////////////////////////////////////////////////
+//                       MISC. METHODS                        //
+////////////////////////////////////////////////////////////////
+
+#define macro SWEEP_LOST(z0) = takes(0) returns(0) {
+    [LOST_N_FOUND]         // [sweep_dest]
+    // -- Load lost tokens.
+    <z0>                   // [sweep_dest, 0]
+    sload                  // [sweep_dest, 0.bal]
+    address                // [sweep_dest, 0.bal, this]
+    sload                  // [sweep_dest, 0.bal, this.bal]
+    // -- Emit Transfer events.
+    dup3                   // [sweep_dest, 0.bal, this.bal, sweep_dest]
+    <z0>                   // [sweep_dest, 0.bal, this.bal, sweep_dest, 0]
+    __EVENT_HASH(Transfer) // [sweep_dest, 0.bal, this.bal, sweep_dest, 0, Transfer.sig]
+    dup5                   // [sweep_dest, 0.bal, this.bal, sweep_dest, 0, Transfer.sig, 0.bal]
+    dup4                   // [sweep_dest, 0.bal, this.bal, sweep_dest, 0, Transfer.sig, 0.bal, sweep_dest]
+    address                // [sweep_dest, 0.bal, this.bal, sweep_dest, 0, Transfer.sig, 0.bal, sweep_dest, this]
+    dup4                   // [sweep_dest, 0.bal, this.bal, sweep_dest, 0, Transfer.sig, 0.bal, sweep_dest, this, Transfer.sig]
+    dup8                   // [sweep_dest, 0.bal, this.bal, sweep_dest, 0, Transfer.sig, 0.bal, sweep_dest, this, Transfer.sig, this.bal]
+    _SWEEP_LOG3(<z0>)      // [sweep_dest, 0.bal, this.bal, sweep_dest, 0, Transfer.sig, 0.bal]
+    _SWEEP_LOG3(<z0>)      // [sweep_dest, 0.bal, this.bal]
+    // -- Increase the balance of the sweep address.
+    add                    // [sweep_dest, sweep_total
+    dup2                   // [sweep_dest, sweep_total, sweep_dest]
+    sload                  // [sweep_dest, sweep_total, sweep_dest.bal]
+    add                    // [sweep_dest, sweep_dest.bal']
+    swap1                  // [sweep_dest.bal', sweep_dest]
+    sstore                 // []
+    // -- Reset balance of the "lost accounts".
+    <z0> <z0>              // [0, 0]
+    sstore                 // []
+    <z0>                   // [0]
+    address                // [0, this]
+    sstore                 // []
+    stop
+}
+
+////////////////////////////////////////////////////////////////
+//               FUNCTION DISPATCHER COMPONENTS               //
+////////////////////////////////////////////////////////////////
+
+#define macro __SELECTOR(z0) = takes(0) returns(1) {
+    // takes:       []
+    <z0>         // [0]
+    calldataload // [cd[0:32]]
+    0xe0         // [cd[0:32], 224]
+    shr          // [selector]
+    // returns:     [selector]
+}
+
+
+/// @dev Size: 8
+#define macro INVALID_NON_PAYABLE() = takes(2) returns(1) {
+    // takes:                [msg.sig, selector]
+    sub                   // [selector != msg.sig]
+    callvalue             // [selector != msg.sig, msg.value]
+    or                    // [selector != msg.sig || (msg.value != 0)]
+    // returns:              [invalid]
+}
+
+/// @dev Size: 3
+#define macro VALID_NON_PAYABLE() = takes(2) returns(1) {
+    // takes:                [selector, msg.sig]
+    eq                    // [selector == msg.sig]
+    callvalue             // [selector == msg.sig, msg.value]
+    _NOTA_AND_B()         // [no_error]
+    // returns:              [no_error]
+}
+
+/// @dev Size: 12
+#define macro __NON_PAYABLE_SELECTOR_CHECK() = takes(2) returns(0) {
+    // takes:                [msg.sig, selector]
+    INVALID_NON_PAYABLE() // [invalid]
+    empty_revert jumpi    // []
+    // returns:              []
+}
+
+/// @dev Size: 10
+#define macro __PAYABLE_SELECTOR_CHECK() = takes(2) returns(0) {
+    // takes:             [msg.sig, selector]
+    sub                // [selector != msg.sig]
+    _REQUIRE_NOT()     // [] -- end
+    // returns:           []
+}
+
+#define macro __NO_MATCH() = takes(0) returns(0) {
+    _REVERT()
+    // Padding to make sure block is 64 bytes large post compilation.
+    /* padding (60) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                       stop stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                       stop stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                       stop stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+}
+
+#define macro __RECEIVE_CHECK() = takes(0) returns(0) {
+    calldatasize empty_revert jumpi
+}
+
+#define macro __FN_DISPATCHER_CORE(z0) = takes(0) returns(1) {
+    __SELECTOR(<z0>)    // [selector]
+    // -- Isolate unique selector bits.
+    dup1                // [selector, selector]
+    [S_SHIFT]           // [selector, selector, sel_shift]
+    shr                 // [selector, unique_sel_bits]
+    // -- Fixed mask for lower bits.
+    [S_COVER]           // [selector, unique_sel_bits, sel_cover]
+    or                  // [selector, jump_dest]
+    jump                // [selector]
+}
+
+////////////////////////////////////////////////////////////////
+//                 DEPLOYMENT & INTIALIZATION                 //
+////////////////////////////////////////////////////////////////
+
+#define macro _CHECK_METADATA(z0, src) = takes(0) returns(0) {
+    <src>                  // [src]
+    dup1                   // [src, src]
+    extcodesize            // [src, src_size]
+    [METADATA_SRC_SIZE]    // [src, src_size, expected_size]
+    sub                    // [src, src_size != expected_size]
+    invalid_metadata jumpi // [src]
+
+    // -- Validate metadata (check symbol.length <= 31 && name.length <= 64).
+    // Format 0x00 <1-byte decimal> <1-byte symbol length> <31-byte symbol> <128-byte ABI encoded name>.
+    0x62                   // [src, 0x62]
+    <z0> <z0>              // [src, 0x62, 0, 0]
+    dup4                   // [src, 0x62, 0, 0, src]
+    // Only copies the first 98 bytes.
+    extcodecopy            // [src]
+    // Check leading 0x00 padding byte.
+    <z0> mload             // [src, metadata_container[:32]]
+    dup1                   // [src, metadata_container[:32], metadata_container[:32]]
+    <z0> byte              // [src, metadata_container[:32], padding_byte]
+    invalid_pop1 jumpi     // [src, metadata_container[:32]]
+    // Check symbol length.
+    0x2 byte               // [src, symbol_length]
+    [MAX_SYMBOL_LEN]       // [src, symbol_length, max_symbol_length]
+    lt                     // [src, symbol_length > max_symbol_length]
+    invalid_metadata jumpi // [src]
+    // Check encoded name offset.
+    0x22 mload             // [src, name_offset]
+    [NAME_ENCODED_OFFSET]  // [src, name_offset, expected_offset]
+    sub                    // [src, name_offset != expected_offset]
+    invalid_metadata jumpi // [src]
+    // Check name length
+    0x42 mload             // [src, name_length]
+    [MAX_NAME_LEN]         // [src, name_length, max_name_length]
+    lt                     // [src, name_length > max_name_length]
+    invalid_metadata jumpi // [src]
+
+    // If valid jump to found, ending search.
+    found_metadata jump    // [src]
+
+    invalid_pop1:          // [src, metadata_container[:32]]
+    pop                    // [src]
+    invalid_metadata:      // [src]
+    pop                    // []
+}
+
+#define macro _INSERT_METADATA(src_offset, length) = takes(2) returns(1) {
+    // takes:               [src, mem_offset]
+    <length>             // [src, mem_offset, length]
+    swap1                // [src, length, mem_offset]
+    <src_offset>         // [src, length, mem_offset, src_offset]
+    swap1                // [src, length, src_offset, mem_offset]
+    dup4                 // [src, length, src_offset, mem_offset, src]
+    extcodecopy          // [src]
+    // returns:             [src]
+}
+
+#define macro _CONSTRUCTOR(z0) = takes(0) returns(0) {
+    // -- Check no msg.value was sent.
+    callvalue                    // [msg.value]
+    empty_revert jumpi           // []
+
+    // -- Determine metadata source (TODO: Add actual addresses).
+    // Deploy testing fallback.
+    _CHECK_METADATA(<z0>, 0x336e5B64961C2629f7AbF5F98cAecb70291A194E)
+    // Fallback address for testing `keccak256("METH.metadata-source.test")[12:32]`
+    _CHECK_METADATA(<z0>, 0x720018705211DC9Bd02277F2c36c0f7b43c0522f)
+    // Revert by default if no metadata source found.
+
+    empty_revert:                // [...]
+        <z0> <z0>                // [..., 0, 0]
+        revert                   // [...] -- end
+    found_metadata:              // [src]
+
+    // -- Copy main code into memory.
+    __codesize(CONSTRUCTOR)      // [src, constructor_size]
+    codesize                     // [src, constructor_size, total_size]
+    sub                          // [src, runtime_size]
+    swap1                        // [runtime_size, src]
+    dup2                         // [runtime_size, src, runtime_size]
+    __codesize(CONSTRUCTOR)      // [runtime_size, src, runtime_size, runtime_offset]
+    <z0>                         // [runtime_size, src, runtime_size, runtime_offset, 0]
+    codecopy                     // [runtime_size, src]
+
+    // -- Insert metadata into code.
+    // Insert decimals.
+    [DECIMALS_OFFSET]            // [runtime_size, src, decimals_offset]
+    _INSERT_METADATA(0x1, 0x1)   // [runtime_size, src]
+    [SYMBOL_OFFSET]              // [runtime_size, src, symbol_offset]
+    _INSERT_METADATA(0x2, 0x20)  // [runtime_size, src]
+    [NAME_OFFSET]                // [runtime_size, src, name_offset]
+    _INSERT_METADATA(0x22, 0x80) // [runtime_size, src]
+    pop                          // [runtime_size]
+
+    // -- Return final code.
+    <z0>                         // [runtime_size, 0]
+    return                       // [] -- end
+}
+
+#define macro CONSTRUCTOR() = takes(0) returns(0) {
+    _CONSTRUCTOR(returndatasize)
+}
+
+////////////////////////////////////////////////////////////////
+//                            MAIN                            //
+////////////////////////////////////////////////////////////////
+
+#define macro MAIN() = takes(0) returns(0) {
+    __FN_DISPATCHER_CORE(returndatasize)
+
+        // Padding to make sure jump dests start at the right offset.
+        /* padding (50) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop
+
+    dest_0x00:
+        __RECEIVE_CHECK()
+        DEPOSIT(returndatasize)
+        /* padding (10) */ stop stop stop stop stop stop stop stop stop stop
+    dest_0x01: __NO_MATCH()
+    dest_0x02: __NO_MATCH()
+    dest_0x03: __NO_MATCH()
+    dest_0x04: __NO_MATCH()
+    dest_0x05: __NO_MATCH()
+    dest_0x06:
+        // 0x06fdde03
+        __FUNC_SIG(name)
+        __NON_PAYABLE_SELECTOR_CHECK()
+        NAME(callvalue)
+        /* padding (41) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop
+    dest_0x07: __NO_MATCH()
+    dest_0x08: __NO_MATCH()
+    dest_0x09:
+        // 0x095ea7b3
+        __FUNC_SIG(approve) 
+        __NON_PAYABLE_SELECTOR_CHECK()
+        APPROVE(callvalue)
+        /// @dev Selectors 0x0a000000 - 0x0affffff will exceptionally revert.
+        /* padding (55) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop
+    dest_0x0b: __NO_MATCH()
+    dest_0x0c: __NO_MATCH()
+    dest_0x0d: __NO_MATCH()
+    dest_0x0e: __NO_MATCH()
+    dest_0x0f: __NO_MATCH()
+    dest_0x10: __NO_MATCH()
+    dest_0x11: __NO_MATCH()
+    dest_0x12: __NO_MATCH()
+    dest_0x13: __NO_MATCH()
+    dest_0x14: __NO_MATCH()
+    dest_0x15: __NO_MATCH()
+    dest_0x16: __NO_MATCH()
+    dest_0x17: __NO_MATCH()
+    dest_0x18:
+        // 0x18160ddd
+        __FUNC_SIG(totalSupply)
+        __NON_PAYABLE_SELECTOR_CHECK()
+        TOTAL_SUPPLY(callvalue)
+        /* padding (45) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop
+    dest_0x19: __NO_MATCH()
+    dest_0x1a: __NO_MATCH()
+    dest_0x1b: __NO_MATCH()
+    dest_0x1c: __NO_MATCH()
+    dest_0x1d: __NO_MATCH()
+    dest_0x1e: __NO_MATCH()
+    dest_0x1f: __NO_MATCH()
+    dest_0x20:
+        // 0x205c2878
+        __FUNC_SIG(withdrawTo)
+        INVALID_NON_PAYABLE()
+        WITHDRAW_TO(callvalue)
+        /// @dev Selectors 0x21000000 - 0x21ffffff will exceptionally revert.
+        /* padding (38) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop
+    dest_0x22: __NO_MATCH()
+    dest_0x23:
+        // 0x23b872dd
+        __FUNC_SIG(transferFrom)
+        INVALID_NON_PAYABLE()
+        TRANSFER_FROM(callvalue)
+        /// @dev Selectors 0x24000000 - 0x24ffffff will exceptionally revert.
+        /* padding (14) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+    dest_0x25: __NO_MATCH()
+    dest_0x26: __NO_MATCH()
+    dest_0x27: __NO_MATCH()
+    dest_0x28:
+        // 0x28026ace
+        __FUNC_SIG(depositAndApprove)
+        __PAYABLE_SELECTOR_CHECK()
+        DEPOSIT_AND_APPROVE(returndatasize)
+        /// @dev Selectors 0x29000000 - 0x29ffffff will exceptionally revert.
+        /* padding (11) */ stop stop stop stop stop stop stop stop stop stop stop
+    dest_0x2a: __NO_MATCH()
+    dest_0x2b: __NO_MATCH()
+    dest_0x2c: __NO_MATCH()
+    dest_0x2d: __NO_MATCH()
+    dest_0x2e:
+        // 0x2e1a7d4d
+        __FUNC_SIG(withdraw)
+        INVALID_NON_PAYABLE()
+        WITHDRAW(callvalue)
+        /// @dev Selectors 0x2f000000 - 0x2fffffff will exceptionally revert.
+        /* padding (40) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop
+    dest_0x30: __NO_MATCH()
+    dest_0x31:
+        // 0x313ce567
+        __FUNC_SIG(decimals)
+        __NON_PAYABLE_SELECTOR_CHECK()
+        DECIMALS(callvalue)
+        /* padding (44) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop
+    dest_0x32: __NO_MATCH()
+    dest_0x33: __NO_MATCH()
+    dest_0x34: __NO_MATCH()
+    dest_0x35: __NO_MATCH()
+    dest_0x36: __NO_MATCH()
+    dest_0x37: __NO_MATCH()
+    dest_0x38: __NO_MATCH()
+    dest_0x39: __NO_MATCH()
+    dest_0x3a: __NO_MATCH()
+    dest_0x3b: __NO_MATCH()
+    dest_0x3c: __NO_MATCH()
+    dest_0x3d: __NO_MATCH()
+    dest_0x3e: __NO_MATCH()
+    dest_0x3f: __NO_MATCH()
+    dest_0x40: __NO_MATCH()
+    dest_0x41: __NO_MATCH()
+    dest_0x42: __NO_MATCH()
+    dest_0x43: __NO_MATCH()
+    dest_0x44: __NO_MATCH()
+    dest_0x45: __NO_MATCH()
+    dest_0x46: __NO_MATCH()
+    dest_0x47: __NO_MATCH()
+    dest_0x48: __NO_MATCH()
+    dest_0x49: __NO_MATCH()
+    dest_0x4a:
+        // 0x4a4089cc
+        __FUNC_SIG(withdrawFromTo)
+        INVALID_NON_PAYABLE()
+        WITHDRAW_FROM_TO(callvalue)
+        /// @dev Selectors 0x4b000000 - 0x4bffffff will exceptionally revert.
+        /* padding (03) */ stop stop stop
+    dest_0x4c: __NO_MATCH()
+    dest_0x4d: __NO_MATCH()
+    dest_0x4e: __NO_MATCH()
+    dest_0x4f: __NO_MATCH()
+    dest_0x50: __NO_MATCH()
+    dest_0x51: __NO_MATCH()
+    dest_0x52: __NO_MATCH()
+    dest_0x53: __NO_MATCH()
+    dest_0x54: __NO_MATCH()
+    dest_0x55: __NO_MATCH()
+    dest_0x56: __NO_MATCH()
+    dest_0x57: __NO_MATCH()
+    dest_0x58: __NO_MATCH()
+    dest_0x59: __NO_MATCH()
+    dest_0x5a: __NO_MATCH()
+    dest_0x5b: __NO_MATCH()
+    dest_0x5c: __NO_MATCH()
+    dest_0x5d: __NO_MATCH()
+    dest_0x5e: __NO_MATCH()
+    dest_0x5f: __NO_MATCH()
+    dest_0x60: __NO_MATCH()
+    dest_0x61: __NO_MATCH()
+    dest_0x62: __NO_MATCH()
+    dest_0x63: __NO_MATCH()
+    dest_0x64: __NO_MATCH()
+    dest_0x65: __NO_MATCH()
+    dest_0x66: __NO_MATCH()
+    dest_0x67: __NO_MATCH()
+    dest_0x68: __NO_MATCH()
+    dest_0x69: __NO_MATCH()
+    dest_0x6a: __NO_MATCH()
+    dest_0x6b: __NO_MATCH()
+    dest_0x6c: __NO_MATCH()
+    dest_0x6d: __NO_MATCH()
+    dest_0x6e: __NO_MATCH()
+    dest_0x6f: __NO_MATCH()
+    dest_0x70:
+        // 0x70a08231
+        __FUNC_SIG(balanceOf)
+        __NON_PAYABLE_SELECTOR_CHECK()
+        BALANCE_OF(callvalue)
+        /* padding (39) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop
+    dest_0x71: __NO_MATCH()
+    dest_0x72: __NO_MATCH()
+    dest_0x73: __NO_MATCH()
+    dest_0x74: __NO_MATCH()
+    dest_0x75: __NO_MATCH()
+    dest_0x76: __NO_MATCH()
+    dest_0x77: __NO_MATCH()
+    dest_0x78: __NO_MATCH()
+    dest_0x79: __NO_MATCH()
+    dest_0x7a: __NO_MATCH()
+    dest_0x7b: __NO_MATCH()
+    dest_0x7c: __NO_MATCH()
+    dest_0x7d: __NO_MATCH()
+    dest_0x7e: __NO_MATCH()
+    dest_0x7f: __NO_MATCH()
+    dest_0x80: __NO_MATCH()
+    dest_0x81: __NO_MATCH()
+    dest_0x82: __NO_MATCH()
+    dest_0x83: __NO_MATCH()
+    dest_0x84: __NO_MATCH()
+    dest_0x85:
+        // 0x853828b6
+        __FUNC_SIG(withdrawAll)
+        __NON_PAYABLE_SELECTOR_CHECK()
+        WITHDRAW_ALL(callvalue)
+        /// @dev Selectors 0x86000000 - 0x86ffffff will exceptionally revert.
+        /* padding (49) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop
+    dest_0x87: __NO_MATCH()
+    dest_0x88: __NO_MATCH()
+    dest_0x89: __NO_MATCH()
+    dest_0x8a: __NO_MATCH()
+    dest_0x8b: __NO_MATCH()
+    dest_0x8c: __NO_MATCH()
+    dest_0x8d: __NO_MATCH()
+    dest_0x8e: __NO_MATCH()
+    dest_0x8f: __NO_MATCH()
+    dest_0x90: __NO_MATCH()
+    dest_0x91: __NO_MATCH()
+    dest_0x92: __NO_MATCH()
+    dest_0x93: __NO_MATCH()
+    dest_0x94:
+        // 0x9470b0bd
+        __FUNC_SIG(withdrawFrom)
+        VALID_NON_PAYABLE()
+        _WITHDRAW_FROM_START(callvalue)
+        /* padding (00) */
+    dest_0x95:
+        // 0x95d89b41
+        __FUNC_SIG(symbol)
+        __NON_PAYABLE_SELECTOR_CHECK()
+        SYMBOL(callvalue)
+        /* padding (08) */ stop stop stop stop stop stop stop stop
+    dest_0x96: __NO_MATCH()
+    dest_0x97: __NO_MATCH()
+    dest_0x98: __NO_MATCH()
+    dest_0x99: __NO_MATCH()
+    dest_0x9a: __NO_MATCH()
+    dest_0x9b: __NO_MATCH()
+    dest_0x9c: __NO_MATCH()
+    dest_0x9d: __NO_MATCH()
+    dest_0x9e: __NO_MATCH()
+    dest_0x9f: __NO_MATCH()
+    dest_0xa0: __NO_MATCH()
+    dest_0xa1: __NO_MATCH()
+    dest_0xa2: __NO_MATCH()
+    dest_0xa3: __NO_MATCH()
+    dest_0xa4: __NO_MATCH()
+    dest_0xa5: __NO_MATCH()
+    dest_0xa6: __NO_MATCH()
+    dest_0xa7: __NO_MATCH()
+    dest_0xa8: __NO_MATCH()
+    dest_0xa9:
+        // 0xa9059cbb
+        __FUNC_SIG(transfer)
+        INVALID_NON_PAYABLE()
+        TRANSFER(callvalue)
+        /// @dev Selectors 0xaa000000 - 0xaaffffff will exceptionally revert.
+        /* padding (49) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop
+    dest_0xab: __NO_MATCH()
+    dest_0xac: __NO_MATCH()
+    dest_0xad:
+        // 0xadfd411c
+        __FUNC_SIG(sweepLost)
+        __NON_PAYABLE_SELECTOR_CHECK()
+        SWEEP_LOST(callvalue)
+        /// @dev Selectors 0xae000000 - 0xaeffffff will exceptionally revert.
+        /* padding (27) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop
+    dest_0xaf: __NO_MATCH()
+    dest_0xb0: __NO_MATCH()
+    dest_0xb1: __NO_MATCH()
+    dest_0xb2: __NO_MATCH()
+    dest_0xb3: __NO_MATCH()
+    dest_0xb4: __NO_MATCH()
+    dest_0xb5: __NO_MATCH()
+    dest_0xb6: __NO_MATCH()
+    dest_0xb7:
+        // 0xb760faf9
+        __FUNC_SIG(depositTo)
+        __PAYABLE_SELECTOR_CHECK()
+        DEPOSIT_TO(returndatasize)
+        /* padding (01) */ stop
+    dest_0xb8: __NO_MATCH()
+    dest_0xb9: __NO_MATCH()
+    dest_0xba: __NO_MATCH()
+    dest_0xbb: __NO_MATCH()
+    dest_0xbc: __NO_MATCH()
+    dest_0xbd: __NO_MATCH()
+    dest_0xbe: __NO_MATCH()
+    dest_0xbf: __NO_MATCH()
+    dest_0xc0: __NO_MATCH()
+    dest_0xc1: __NO_MATCH()
+    dest_0xc2: __NO_MATCH()
+    dest_0xc3: __NO_MATCH()
+    dest_0xc4: __NO_MATCH()
+    dest_0xc5: __NO_MATCH()
+    dest_0xc6: __NO_MATCH()
+    dest_0xc7: __NO_MATCH()
+    dest_0xc8: __NO_MATCH()
+    dest_0xc9: __NO_MATCH()
+    dest_0xca:
+        // 0xca9add8f
+        __FUNC_SIG(withdrawAllTo)
+        __NON_PAYABLE_SELECTOR_CHECK()
+        WITHDRAW_ALL_TO(callvalue)
+        /// @dev Selectors 0xcb000000 - 0xcbffffff will exceptionally revert.
+        /* padding (47) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop
+    dest_0xcc: __NO_MATCH()
+    dest_0xcd: __NO_MATCH()
+    dest_0xce: __NO_MATCH()
+    dest_0xcf: __NO_MATCH()
+    dest_0xd0: 
+        // 0xd0e30db0
+        __FUNC_SIG(deposit)
+        __PAYABLE_SELECTOR_CHECK()
+        DEPOSIT(returndatasize)
+        /* padding (06) */ stop stop stop stop stop stop
+    dest_0xd1: __NO_MATCH()
+    dest_0xd2: __NO_MATCH()
+    dest_0xd3: __NO_MATCH()
+    dest_0xd4: __NO_MATCH()
+    dest_0xd5: __NO_MATCH()
+    dest_0xd6: __NO_MATCH()
+    dest_0xd7: __NO_MATCH()
+    dest_0xd8: __NO_MATCH()
+    dest_0xd9: __NO_MATCH()
+    dest_0xda: __NO_MATCH()
+    dest_0xdb: __NO_MATCH()
+    dest_0xdc: __NO_MATCH()
+    dest_0xdd:
+        // 0xdd62ed3e
+        __FUNC_SIG(allowance)
+        __NON_PAYABLE_SELECTOR_CHECK()
+        ALLOWANCE(callvalue)
+        /* padding (34) */ stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop stop stop stop stop stop stop stop stop
+                           stop stop stop stop stop stop
+    dest_0xde: __NO_MATCH()
+    dest_0xdf: __NO_MATCH()
+    dest_0xe0: __NO_MATCH()
+    dest_0xe1: __NO_MATCH()
+    dest_0xe2: __NO_MATCH()
+    dest_0xe3: __NO_MATCH()
+    dest_0xe4: __NO_MATCH()
+    dest_0xe5: __NO_MATCH()
+    dest_0xe6: __NO_MATCH()
+    dest_0xe7: __NO_MATCH()
+    dest_0xe8: __NO_MATCH()
+    dest_0xe9: __NO_MATCH()
+    dest_0xea: __NO_MATCH()
+    dest_0xeb: __NO_MATCH()
+    dest_0xec: __NO_MATCH()
+    dest_0xed: __NO_MATCH()
+    dest_0xee: __NO_MATCH()
+    dest_0xef: __NO_MATCH()
+    dest_0xf0: __NO_MATCH()
+    dest_0xf1: __NO_MATCH()
+    dest_0xf2: __NO_MATCH()
+    dest_0xf3: __NO_MATCH()
+    dest_0xf4: __NO_MATCH()
+    dest_0xf5: __NO_MATCH()
+    dest_0xf6: __NO_MATCH()
+    dest_0xf7: __NO_MATCH()
+    dest_0xf8: __NO_MATCH()
+    dest_0xf9: __NO_MATCH()
+    dest_0xfa: __NO_MATCH()
+    dest_0xfb: __NO_MATCH()
+    dest_0xfc: __NO_MATCH()
+    dest_0xfd: __NO_MATCH()
+    dest_0xfe: __NO_MATCH()
+    empty_revert: _REVERT()
+
+    _TRANSFER_FROM_INF_END(callvalue)
+    _WITHDRAW_FROM_END(callvalue)
+    _WITHDRAW_FROM_TO_INF_END(callvalue)
+}

--- a/huff_cli/examples/SudoOpenseaArb.huff
+++ b/huff_cli/examples/SudoOpenseaArb.huff
@@ -1,0 +1,194 @@
+//! # Sudo x Opensea Arbitrage Contract
+//!
+//! Contains the logic for permissioned Sudo x Opensea arbitrage transactions.
+
+#include "./LibConst.huff"
+#include "./LibCall.huff"
+
+/// ## Unauthorized Error
+#define error Unauthorized()
+
+/// ## No Profit Error
+#define error NoProfit()
+
+/// ## Initcode
+///
+/// ### Directives
+///
+/// 1. Store the caller as the owner in storage.
+/// 2. Return the runtime code (implicit).
+#define macro CONSTRUCTOR() = takes (0) returns (0) {
+    caller                  // [caller]
+    [OWNER_SLOT]            // [owner_slot, caller]
+    sstore                  // []
+}
+
+/// ## Program Entry Point
+///
+/// ### Directives
+///
+/// 1. Extracts the 4 byte function selector from calldata.
+/// 2. Dispatches to the appropriate function, ordered to optimize gas usage.
+/// 3. If no selector matches, halt gracefully to allow ether in-transfers.
+///
+/// #### Selector Ordering
+///
+/// We order selectors by view vs stateful calls first, then by expected frequency of use.
+///
+/// 1. `executeArb` executes arbitrage, highest frequency with gas required.
+/// 2. `withdraw` withdraws funds, less frequent with gas required.
+/// 3. `transferOwner` transfers ownership, least frequent with gas required.
+/// 4. `owner` returns owner, no gas required.
+///
+/// ### Panics
+///
+/// - When a dispatched function panics.
+#define macro MAIN() = takes (0) returns (0) {
+    // dispatch function by its selector
+    0x00 calldataload 0xe0 shr
+    dup1 [EXECUTE_ARB_SEL] eq is_execute_arb jumpi
+    dup1 [WITHDRAW_SEL] eq is_withdraw jumpi
+    dup1 [TRANSFER_OWNERSHIP_SEL] eq is_transfer_ownership jumpi
+    [OWNER_SEL] eq is_get_owner jumpi
+
+    // if no selector matches, it's an ether transfer, so we halt gracefully.
+    stop
+
+    // execute arbitrage
+    is_execute_arb:
+        EXECUTE_ARB()
+
+    // execute withdraw
+    is_withdraw:
+        WITHDRAW()
+
+    // execute ownership transfer
+    is_transfer_ownership:
+        TRANFSER_OWNERSHIP()
+
+    // get owner
+    is_get_owner:
+        GET_OWNER()
+}
+
+/// ## Execute Arbitrage
+///
+/// ### Directives
+///
+/// 1. Cache the initial self balance.
+/// 2. Call `fulfillBasicOrder` on Opensea.
+/// 3. Call `approve` to delegate transfer permission to Sudo.
+/// 4. Call `swapNFTsForTokens` on the Sudo.
+/// 5. Checks that the contract made a profit, panics if not.
+/// 6. Halt gracefully.
+///
+/// ### Panics
+///
+/// - When `CALL_FULFILL_BASIC_ORDER` panics.
+/// - When `CALL_APPROVE` panics.
+/// - When `CALL_SWAP` panics.
+/// - When the contract did not make a profit.
+#define macro EXECUTE_ARB() = takes (0) returns (0) {
+    selfbalance                 // [init_bal]
+    CALL_FULFILL_BASIC_ORDER()  // [init_bal]
+    CALL_APPROVE()              // [init_bal]
+    CALL_SWAP()                 // [init_bal]
+    selfbalance                 // [after_bal, init_bal]
+    gt                          // [made_profit]
+    made_profit                 // [made_profit_dest, made_profit]
+    jumpi                       // []
+        __ERROR(NoProfit)       // [no_profit_err]
+        0x00 mstore             // []
+        0x04 0x00 revert        // []
+    made_profit:                // []
+        stop                    // []
+}
+
+/// ## Withdraw Funds
+///
+/// ### Directives
+///
+/// 1. Load the owner from storage.
+/// 2. Checks that the caller is the owner, panics if not.
+/// 3. Transfer the contract's ether balance to the caller.
+/// 4. Halt gracefully, regardless of success.
+///
+/// ### Panics
+///
+/// - When the caller is not the owner.
+#define macro WITHDRAW() = takes (0) returns (0) {
+    [OWNER_SLOT]                // [owner_slot]
+    sload                       // [owner]
+    caller                      // [caller, owner]
+    eq                          // [is_owner]
+    is_owner                    // [is_owner_dest, is_owner]
+    jumpi                       // []
+        __ERROR(Unauthorized)   // [unauthorized_err]
+        0x00                    // [mem_ptr, unauthorized_err]
+        mstore                  // []
+        0x04                    // [mem_len]
+        0x00                    // [mem_ptr, mem_len]
+        revert                  // []
+
+    is_owner:                   // []
+        0x00                    // [ret_len]
+        0x00                    // [ret_ptr, ret_len]
+        0x00                    // [arg_len, ret_ptr, ret_len]
+        0x00                    // [arg_ptr, arg_len, ret_ptr, ret_len]
+        selfbalance             // [value, arg_ptr, arg_len, ret_ptr, ret_len]
+        caller                  // [target, value, arg_ptr, arg_len, ret_ptr, ret_len]
+        gas                     // [gas, target, value, arg_ptr, arg_len, ret_ptr, ret_len]
+        call                    // [success]
+        stop                    // []
+}
+
+/// ## Transfer Ownership
+///
+/// ### Directives
+///
+/// 1. Load the owner from storage.
+/// 2. Checks that the caller is the owner, panics if not.
+/// 3. Load the new owner from calldata.
+/// 4. Store the new owner in storage.
+/// 5. Halt gracefully.
+///
+/// ### Panics
+///
+/// - When the caller is not the owner.
+#define macro TRANFSER_OWNERSHIP() = takes (0) returns (0) {
+    [OWNER_SLOT]                // [owner_slot]
+    sload                       // [owner]
+    caller                      // [caller, owner]
+    eq                          // [is_owner]
+    is_owner                    // [is_owner_dest, is_owner]
+    jumpi                       // []
+        __ERROR(Unauthorized)   // [unauthorized_err]
+        0x00                    // [mem_ptr, unauthorized_err]
+        mstore                  // []
+        0x04                    // [mem_len]
+        0x00                    // [mem_ptr, mem_len]
+        revert                  // []
+
+    is_owner:                   // []
+        0x04                    // [new_owner_ptr]
+        calldataload            // [new_owner]
+        [OWNER_SLOT]            // [owner_slot, new_owner]
+        sstore                  // []
+        stop                    // []
+}
+
+/// ## Get Owner
+///
+/// ### Directives
+///
+/// 1. Load the owner from storage.
+/// 2. Return the owner.
+#define macro GET_OWNER() = takes (0) returns (0) {
+    [OWNER_SLOT]            // [owner_slot]
+    sload                   // [owner]
+    0x00                    // [mem_ptr, owner]
+    mstore                  // []
+    0x20                    // [mem_len]
+    0x00                    // [mem_ptr, mem_len]
+    return                  // []
+}

--- a/huff_cli/examples/simple.huff
+++ b/huff_cli/examples/simple.huff
@@ -1,0 +1,7 @@
+#define constant S_SHIFT = 12
+#define macro _NAME_OF_FUNCTION() = takes(2) returns(0) {
+   40
+   40
+   call          // fsdfdsf
+   calldatacopy
+}

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use huff_lexer::Lexer;
 use huff_utils::prelude::*;
 
@@ -7,19 +8,23 @@ use generator::Generator;
 mod evm;
 use evm::OpcodeFormatted;
 
-fn main() {
-    // Instantiate a new lexer
-    let source = r#"
-        #define constant S_SHIFT = 12
-        #define macro _NAME_OF_FUNCTION() = takes(2) returns(0) {
-           40
-           40
-           call          // fsdfdsf
-           calldatacopy
-        }
-    "#;
+use crate::opts::Opts;
 
-    let flattened_source = FullFileSource { source, file: None, spans: vec![] };
+mod opts;
+
+fn main() {
+    // parsing args
+    let opts = Opts::parse();
+
+    // Check if input is specified as path or passed directly as a string
+    let inputs = opts.inputs;
+    let source = if let Some(path) = inputs.path {
+        std::fs::read_to_string(&path).unwrap()
+    } else {
+        inputs.input.unwrap()
+    };
+
+    let flattened_source = FullFileSource { source: &source, file: None, spans: vec![] };
     let lexer = Lexer::new(flattened_source.source);
 
     // remove the whitespace tokens

--- a/huff_cli/src/opts.rs
+++ b/huff_cli/src/opts.rs
@@ -1,0 +1,20 @@
+use clap::{Args, Parser, ValueHint};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Opts {
+    #[command(flatten)]
+    pub inputs: Inputs,
+}
+
+#[derive(Args, Debug)]
+#[group(required = false, multiple = false)]
+pub struct Inputs {
+    /// Path to huff contract
+    #[clap(value_hint = ValueHint::FilePath, value_name = "PATH")]
+    #[arg(short, long)]
+    pub path: Option<String>,
+
+    /// Input string
+    pub input: Option<String>,
+}


### PR DESCRIPTION
Using clap crate add input source argument which can be either path to specific file or directly input.
Example of usage:
```bash
cargo run -- -p ./examples/simple.huff

cargo run -- "#define constant MAX = 10
#define constant MIN = 10"
```
Also adding meth and sudo opensea arb huff contracts as benchmarks