### PR TITLE
Update ci task to use clippy stable toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           cache-on-failure: false
       - name: cargo clippy
-        run: cargo +nightly clippy --all --all-features -- -D warnings
+        run: cargo clippy --all --all-features -- -D warnings
 
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Nightly clippy toolchain linting might be an overkill, there are too many changes that we would have to follow. I think stable toolchain is enough for the purpose.